### PR TITLE
Fix OAuth cancel 500 error

### DIFF
--- a/src/Events/TweetPosted.php
+++ b/src/Events/TweetPosted.php
@@ -12,6 +12,5 @@ class TweetPosted
     public function __construct(
         public mixed $notifiable,
         public TweetLog $tweetLog
-    ) {
-    }
+    ) {}
 }

--- a/src/Http/Controllers/TwitterAuthController.php
+++ b/src/Http/Controllers/TwitterAuthController.php
@@ -55,6 +55,15 @@ class TwitterAuthController extends Controller
      */
     public function handleTwitterCallback(Request $request, TwitterService $service): RedirectResponse
     {
+        if ($request->has('error') || ! $request->filled('code')) {
+            return Redirect::to(
+                path: config('autotweet-for-laravel.redirect_path')
+            )->with(
+                key: 'error',
+                value: 'Twitter authentication cancelled.'
+            );
+        }
+
         $service->handleCallback(
             state: $request->get('state'),
             code: $request->get('code')

--- a/src/Services/TwitterService.php
+++ b/src/Services/TwitterService.php
@@ -17,9 +17,7 @@ use Random\RandomException;
 
 class TwitterService
 {
-    public function __construct(public TwitterOAuth $api)
-    {
-    }
+    public function __construct(public TwitterOAuth $api) {}
 
     /**
      * Prepare the authorization URL.
@@ -78,7 +76,7 @@ class TwitterService
     {
         // Validate the state
         if ($state !== session('twitter_state')) {
-            throw new InvalidStateException();
+            throw new InvalidStateException;
         }
 
         // Store the refresh token and get access token

--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -10,9 +10,7 @@ use Illuminate\Notifications\Notification;
 
 class TwitterChannel
 {
-    public function __construct(protected TwitterService $service)
-    {
-    }
+    public function __construct(protected TwitterService $service) {}
 
     /**
      * Send the given notification.
@@ -49,7 +47,7 @@ class TwitterChannel
             throw CouldNotSendNotification::serviceRespondsNotSuccessful($this->service->api->getLastBody());
         }
 
-        $tweetLog = new TweetLog();
+        $tweetLog = new TweetLog;
         $tweetLog->fill([
             'tweet_id' => $twitterApiResponse->data->id,
             'user_id' => $notifiable->id,

--- a/src/TwitterImage.php
+++ b/src/TwitterImage.php
@@ -10,9 +10,7 @@ readonly class TwitterImage
     /**
      * TwitterImage constructor.
      */
-    public function __construct(private string $imagePath)
-    {
-    }
+    public function __construct(private string $imagePath) {}
 
     /**
      * Get the image path.

--- a/src/TwitterMessage.php
+++ b/src/TwitterMessage.php
@@ -6,9 +6,7 @@ abstract class TwitterMessage
 {
     public bool $isJsonRequest = true;
 
-    public function __construct(protected string $content)
-    {
-    }
+    public function __construct(protected string $content) {}
 
     public function getContent(): string
     {

--- a/src/TwitterStatusUpdate.php
+++ b/src/TwitterStatusUpdate.php
@@ -19,7 +19,7 @@ class TwitterStatusUpdate extends TwitterMessage
     {
         parent::__construct($content);
 
-        if ($exceededLength = $this->messageIsTooLong(new Brevity())) {
+        if ($exceededLength = $this->messageIsTooLong(new Brevity)) {
             throw CouldNotSendNotification::statusUpdateTooLong($exceededLength);
         }
     }

--- a/tests/TwitterAuthCancelTest.php
+++ b/tests/TwitterAuthCancelTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use ClaraLeigh\AutotweetForLaravel\Http\Controllers\TwitterAuthController;
+use ClaraLeigh\AutotweetForLaravel\Services\TwitterService;
+use Illuminate\Http\Request;
+
+it('redirects when OAuth is cancelled', function () {
+    session(['twitter_state' => 'foo']);
+    $request = Request::create('/oauth2/twitter/callback', 'GET', [
+        'state' => 'foo',
+        'error' => 'access_denied',
+    ]);
+
+    $service = Mockery::mock(TwitterService::class);
+    $service->shouldNotReceive('handleCallback');
+
+    $controller = new TwitterAuthController();
+    $response = $controller->handleTwitterCallback($request, $service);
+
+    expect($response->getTargetUrl())->toBe(url('/'));
+    expect(session('error'))->toBe('Twitter authentication cancelled.');
+});

--- a/tests/TwitterAuthCancelTest.php
+++ b/tests/TwitterAuthCancelTest.php
@@ -14,7 +14,7 @@ it('redirects when OAuth is cancelled', function () {
     $service = Mockery::mock(TwitterService::class);
     $service->shouldNotReceive('handleCallback');
 
-    $controller = new TwitterAuthController();
+    $controller = new TwitterAuthController;
     $response = $controller->handleTwitterCallback($request, $service);
 
     expect($response->getTargetUrl())->toBe(url('/'));


### PR DESCRIPTION
## Summary
- handle cancelled OAuth flows gracefully
- add coverage for OAuth cancel redirect

## Testing
- `composer test`